### PR TITLE
change www.udacity.com to udacity.github.io links

### DIFF
--- a/crawling.html
+++ b/crawling.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 I have not learned to crawl yet, but I am quite good at 
-<a href="http://www.udacity.com/cs101x/kicking.html">kicking</a>.
+<a href="https://udacity.github.io/cs101x/kicking.html">kicking</a>.
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 This is a test page for learning to crawl!
 <p>
 It is a good idea to 
-<a href="http://www.udacity.com/cs101x/crawling.html">learn to crawl</a>
+<a href="https://udacity.github.io/cs101x/crawling.html">learn to crawl</a>
 before you try to 
-<a href="http://www.udacity.com/cs101x/walking.html">walk</a> or 
-<a href="http://www.udacity.com/cs101x/flying.html">fly</a>.
+<a href="https://udacity.github.io/cs101x/walking.html">walk</a> or 
+<a href="https://udacity.github.io/cs101x/flying.html">fly</a>.
 </p>
 </body>
 </html>

--- a/urank/arsenic.html
+++ b/urank/arsenic.html
@@ -6,7 +6,7 @@ The Arsenic Chef's World Famous Hummus Recipe
 <p>
 
 <ol>
-<li> Kidnap the <a href="http://udacity.com/cs101x/urank/nickel.html">Nickel Chef</a>.
+<li> Kidnap the <a href="https://udacity.github.io/cs101x/urank/nickel.html">Nickel Chef</a>.
 <li> Force her to make hummus for you.
 </ol>
 

--- a/urank/index.html
+++ b/urank/index.html
@@ -4,14 +4,14 @@
 <p>
 Here are my favorite recipies:
 <ul>
-<li> <a href="http://udacity.com/cs101x/urank/hummus.html">Hummus Recipe</a>
-<li> <a href="http://udacity.com/cs101x/urank/arsenic.html">World's Best Hummus</a>
-<li> <a href="http://udacity.com/cs101x/urank/kathleen.html">Kathleen's Hummus Recipe</a>
+<li> <a href="https://udacity.github.io/cs101x/urank/hummus.html">Hummus Recipe</a>
+<li> <a href="https://udacity.github.io/cs101x/urank/arsenic.html">World's Best Hummus</a>
+<li> <a href="https://udacity.github.io/cs101x/urank/kathleen.html">Kathleen's Hummus Recipe</a>
 </ul>
 
 For more expert opinions, check out the 
-<a href="http://udacity.com/cs101x/urank/nickel.html">Nickel Chef</a> 
-and <a href="http://udacity.com/cs101x/urank/zinc.html">Zinc Chef</a>.
+<a href="https://udacity.github.io/cs101x/urank/nickel.html">Nickel Chef</a> 
+and <a href="https://udacity.github.io/cs101x/urank/zinc.html">Zinc Chef</a>.
 </body>
 </html>
 

--- a/urank/nickel.html
+++ b/urank/nickel.html
@@ -3,7 +3,7 @@
 <h1>The Nickel Chef</h1>
 <p>
 This is the
-<a href="http://udacity.com/cs101x/urank/kathleen.html">
+<a href="https://udacity.github.io/cs101x/urank/kathleen.html">
 best Hummus recipe!
 </a>
 

--- a/urank/zinc.html
+++ b/urank/zinc.html
@@ -3,11 +3,11 @@
 <h1>The Zinc Chef</h1>
 <p>
 I learned everything I know from 
-<a href="http://udacity.com/cs101x/urank/nickel.html">the Nickel Chef</a>.
+<a href="https://udacity.github.io/cs101x/urank/nickel.html">the Nickel Chef</a>.
 </p>
 <p>
 For great hummus, try 
-<a href="http://udacity.com/cs101x/urank/arsenic.html">this recipe</a>.
+<a href="https://udacity.github.io/cs101x/urank/arsenic.html">this recipe</a>.
 
 </body>
 </html>

--- a/walking.html
+++ b/walking.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 I can't get enough 
-<a href="http://www.udacity.com/cs101x/index.html">crawling</a>!
+<a href="https://udacity.github.io/cs101x/index.html">crawling</a>!
 </body>
 </html>


### PR DESCRIPTION
Currently all links result in 404, making the test page for cs101 course broken. This change fixes all www.udacity.com and udacity.com links to udacity.github.io ones, which work.